### PR TITLE
Target mbed version update to 1.x.x

### DIFF
--- a/target.json
+++ b/target.json
@@ -9,7 +9,7 @@
     }
   ],
   "inherits": {
-    "mbed-armcc": "~0.1.0"
+    "mbed-armcc": "^1.0.0"
   },
   "keywords": [
     "mbed-target:nuc472-nubed",


### PR DESCRIPTION
Without this change-set, the latest versions of core-util won't build as it uses c++11. Tested locally.